### PR TITLE
Add support for using SVGs instead of text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,8 +467,12 @@ or
         ]
     ]
 
+#### `LBL_IMAGE`
+value is expected to be a string specifying an SVG filename. `LBL_TEXT` takes priority over `LBL_IMAGE`, so if both are provided, only the string will be used. **Warning:** this option will slow things down considerably.
+e.g. `[ LBL_IMAGE, "image.svg" ]`
+
 #### `LBL_SIZE`
-value is expected to either be `AUTO` or a number. `AUTO` will attempt to scale the label to fit in the space according to _width_. This does not work will with very short words. A number will specify the font size.  
+value is expected to either be `AUTO` or a number. `AUTO` will attempt to scale the label to fit in the space according to _width_. This does not work will with very short words. A number will specify the font size (if `LBL_TEXT`) or the image width (if `LBL_IMAGE`).
 e.g. `[ LBL_SIZE, 12 ]`
 
 #### `LBL_SPACING`


### PR DESCRIPTION
I figure I'm probably going to make more suggestions for changes (like this), so I forked a repo after all. 🤣

Since OpenSCAD supports images via SVG, it'd be nice if images could be used for labels. This pull request adds that support.

Tested:
**Single compartment with label**
![image_single](https://user-images.githubusercontent.com/77087101/103994495-f1705500-514b-11eb-923f-06c5bfd94b01.png)

**Multiple compartments with labels**
![image_multi](https://user-images.githubusercontent.com/77087101/103994556-00ef9e00-514c-11eb-9617-c0785191586c.png)

**Lid with label**
![image_lid](https://user-images.githubusercontent.com/77087101/103994575-0a790600-514c-11eb-9cf7-5f6667966656.png)

**Lid with sized label**
![image_lid_size](https://user-images.githubusercontent.com/77087101/103994595-0f3dba00-514c-11eb-83e9-8a496c66002a.png)

The four tests above, but with standard text labels, were performed but not screenshotted. I should have an actual photo sometime tomorrow of one that's been produced.