### PR TITLE
Fix LID patterns sometimes not extending to the edge.

### DIFF
--- a/boardgame_insert_toolkit_lib.3.scad
+++ b/boardgame_insert_toolkit_lib.3.scad
@@ -1506,9 +1506,9 @@ module MakeBox( box )
             //echo( str(y, " ", dy, " ", y_count_i, " ", y_count_even, "\n") );
 
             translate( [x_offset, y_offset, 0 ] )
-            for( j = [ -1: y_count + 1 ] )
+            for( j = [ -1: y_count + 2 ] )
                 translate( [ ( j % 2 ) * dx/2, 0, 0 ] )
-                    for( i = [ -1: x_count + 1 ] )
+                    for( i = [ -1: x_count + 2 ] )
                         translate( [ i * dx, j * dy, 0 ] )
                             rotate( a = m_lid_pattern_angle, v=[ 0, 0, 1 ] )
                             {


### PR DESCRIPTION
Before:
<img width="475" height="370" alt="image" src="https://github.com/user-attachments/assets/3a135e46-8cdd-4267-b33e-0575133be5f3" />
After:
<img width="475" height="370" alt="image" src="https://github.com/user-attachments/assets/051049c1-d94f-48fe-bca4-e29f4ef0eae4" />
